### PR TITLE
feat: 유저의 타자 결과를 DB에 저장하거나, 지난 결과들을 DB로부터 불러와 전달하는 로직 추가

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -1,14 +1,12 @@
 const mongoose = require('mongoose');
 require('mongoose-type-email');
 
-const languageRecordSchema = new mongoose.Schema(
-  {
-    language: String,
-    maxTypingSpeed: Number,
-    accuracy: Number,
-  },
-  { timestamps: true },
-);
+const languageRecordSchema = new mongoose.Schema({
+  language: String,
+  typingSpeed: Number,
+  accuracy: Number,
+  time: String,
+});
 
 const userSchema = new mongoose.Schema(
   {

--- a/routes/controller/users.controller.js
+++ b/routes/controller/users.controller.js
@@ -46,8 +46,76 @@ exports.patch = async (req, res, next) => {
   res.json('users_ok');
 };
 
-exports.recordGet = (req, res, next) => {
-  console.log(req.params.id);
-  console.log(req.params.language);
-  res.json('record_ok');
+exports.recordGet = async (req, res, next) => {
+  const id = req.params.id;
+  const language = req.params.language;
+
+  try {
+    const userInfomation = await User.findById(id).lean();
+
+    if (!userInfomation) {
+      return next({ status: 400, message: 'Bad Request' });
+    }
+
+    const totalRecords = userInfomation.languageRecord;
+    const result = [];
+
+    for (const record of totalRecords) {
+      if (record.language === language) {
+        const data = {
+          typingSpeed: record.typingSpeed,
+          accuracy: record.accuracy,
+          time: record.time,
+        };
+
+        result.push(data);
+      }
+    }
+
+    res.json(result);
+  } catch (err) {
+    return next(err);
+  }
+};
+
+exports.recordPatch = async (req, res, next) => {
+  const id = req.params.id;
+  const language = req.params.language;
+  const { typingSpeed, accuracy, time } = req.body;
+
+  if (!LANGUAGE_LIST.includes(language)) {
+    return next({ status: 400, message: 'Invalid Programming Language' });
+  }
+
+  if (typeof typingSpeed !== 'number') {
+    return next({ status: 400, message: 'typingSpeed is not a number type' });
+  }
+
+  if (typeof accuracy !== 'number') {
+    return next({ status: 400, message: 'accuracy is not a number type' });
+  }
+
+  try {
+    const result = await User.findOneAndUpdate(
+      { _id: id },
+      {
+        $push: {
+          languageRecord: {
+            language,
+            typingSpeed,
+            accuracy,
+            time,
+          },
+        },
+      },
+      { new: true },
+    );
+
+    if (!result) {
+      return next({ status: 400, message: 'Bad Request' });
+    }
+  } catch (err) {
+    return next(err);
+  }
+  res.json('record_patch_ok');
 };

--- a/routes/users.js
+++ b/routes/users.js
@@ -3,7 +3,8 @@ const router = express.Router();
 
 const usersController = require('./controller/users.controller');
 
-router.get('/:id/recode/:language', usersController.recordGet);
+router.get('/:id/record/:language', usersController.recordGet);
+router.patch('/:id/record/:language', usersController.recordPatch);
 
 router.get('/:id', usersController.get);
 router.patch('/:id', usersController.patch);


### PR DESCRIPTION
## 코드를 작성한 이유

- 유저의 지난 기록을 조회하거나, 저장할 수 있도록 해주는 요청이 필요했음

## 무엇이 변하였는가

- patch 요청을 통해 기록이 전달되면, 이를 DB에 저장하도록 해주는 로직, get 요청이 들어오면 해당 언어에 대한 기록들을 응답해주는 로직을 새롭게 구현하였음

## 작성한 코드에 문제점이 존재하는가

- 없음. 하지만 추후에 에러핸들링을 더욱더 확대할 필요성이 있어보임

## 리뷰 중점사항 

- 
